### PR TITLE
Update bootstrap photo gallery stylesheet

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/image-gallery.css
+++ b/vendor/assets/stylesheets/bootstrap/image-gallery.css
@@ -1,6 +1,6 @@
 @charset 'UTF-8';
 /*
- * Bootstrap Image Gallery CSS 2.5
+ * Bootstrap Image Gallery CSS 2.5.3
  * https://github.com/blueimp/Bootstrap-Image-Gallery
  *
  * Copyright 2011, Sebastian Tschan
@@ -13,6 +13,10 @@
 .modal-gallery {
   width: auto;
   max-height: none;
+  outline: none;
+}
+.modal-gallery.fade.in {
+  top: 50%;
 }
 .modal-gallery .modal-body {
   max-height: none;
@@ -63,7 +67,7 @@
   display: none;
 }
 .modal-loading .modal-image {
-  background: url(/assets/bootstrap/image-gallery/loading.gif) center no-repeat;
+  background: url(../img/loading.gif) center no-repeat;
 }
 .modal-gallery.fade .modal-image {
   -webkit-transition: width 0.15s ease, height 0.15s ease;
@@ -134,8 +138,12 @@
   opacity: 1;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 767px) {
   .modal-gallery .btn span {
     display: none;
+  }
+  .modal-fullscreen {
+    right: 0;
+    left: 0;
   }
 }

--- a/vendor/assets/stylesheets/bootstrap/image-gallery.min.css
+++ b/vendor/assets/stylesheets/bootstrap/image-gallery.min.css
@@ -1,12 +1,13 @@
 @charset 'UTF-8';
-.modal-gallery{width:auto;max-height:none;}
+.modal-gallery{width:auto;max-height:none;outline:none;}
+.modal-gallery.fade.in{top:50%;}
 .modal-gallery .modal-body{max-height:none;}
 .modal-gallery .modal-title{display:inline-block;max-height:54px;overflow:hidden;}
 .modal-gallery .modal-image{position:relative;margin:auto;min-width:128px;min-height:128px;overflow:hidden;cursor:pointer;}
 .modal-gallery .modal-image:hover:before,.modal-gallery .modal-image:hover:after{content:'\2039';position:absolute;top:50%;left:15px;width:40px;height:40px;margin-top:-20px;font-size:60px;font-weight:100;line-height:30px;color:#ffffff;text-align:center;background:#222222;border:3px solid #ffffff;-webkit-border-radius:23px;-moz-border-radius:23px;border-radius:23px;opacity:0.5;filter:alpha(opacity=50);z-index:1;}
 .modal-gallery .modal-image:hover:after{content:'\203A';left:auto;right:15px;}
 .modal-single .modal-image:hover:before,.modal-single .modal-image:hover:after{display:none;}
-.modal-loading .modal-image{background:url(/assets/bootstrap/image-gallery/loading.gif) center no-repeat;}
+.modal-loading .modal-image{background:url(../img/loading.gif) center no-repeat;}
 .modal-gallery.fade .modal-image{-webkit-transition:width 0.15s ease, height 0.15s ease;-moz-transition:width 0.15s ease, height 0.15s ease;-ms-transition:width 0.15s ease, height 0.15s ease;-o-transition:width 0.15s ease, height 0.15s ease;transition:width 0.15s ease, height 0.15s ease;}
 .modal-gallery .modal-image *{position:absolute;top:0;opacity:0;filter:alpha(opacity=0);}
 .modal-gallery.fade .modal-image *{-webkit-transition:opacity 0.5s linear;-moz-transition:opacity 0.5s linear;-ms-transition:opacity 0.5s linear;-o-transition:opacity 0.5s linear;transition:opacity 0.5s linear;}
@@ -18,4 +19,4 @@
 .modal-fullscreen .modal-footer{top:auto;bottom:0;}
 .modal-fullscreen .close,.modal-fullscreen .modal-title{color:#fff;text-shadow:0 0 2px rgba(33, 33, 33, 0.8);}
 .modal-fullscreen .modal-header:hover,.modal-fullscreen .modal-footer:hover{opacity:1;}
-@media (max-width:480px){.modal-gallery .btn span{display:none;}}
+@media (max-width:767px){.modal-gallery .btn span{display:none;} .modal-fullscreen{right:0;left:0;}}


### PR DESCRIPTION
The current version of the css is unusable, the .modal.fade.in is not override and the modal is not centered on the screen. In the last version we have

```
.modal.fade.in
  top: 50px
```

It solves this issue.
